### PR TITLE
Support web-mode

### DIFF
--- a/flycheck-flow.el
+++ b/flycheck-flow.el
@@ -67,7 +67,7 @@ See URL `http://flowtype.org/'."
 	    ": "
 	    (message (minimal-match (and (one-or-more anything) "\n")))
 	    line-end))
-    :modes (js-mode js2-mode js3-mode))
+    :modes (js-mode js2-mode js3-mode web-mode))
 
 (add-to-list 'flycheck-checkers 'javascript-flow t)
 


### PR DESCRIPTION
`flycheck-flow` seems to work just fine with `web-mode`. I find it a useful combination for React development in particular, as `web-mode` supports JSX better than the other Javascript modes I know of.
