### PR TITLE
Fix command line argument typo

### DIFF
--- a/flycheck-flow.el
+++ b/flycheck-flow.el
@@ -53,7 +53,7 @@
 See URL `http://flowtype.org/'."
     :command (
               "flow"
-              "check-content"
+              "check-contents"
               (eval flycheck-javascript-flow-args)
               "--old-output-format"
               "--color=never"


### PR DESCRIPTION
Somehow I typo'd this in the version I submitted, it's `check-contents`
