### PR TITLE
Add web-mode to `:modes`

### DIFF
--- a/flycheck-flow.el
+++ b/flycheck-flow.el
@@ -126,7 +126,7 @@ See URL `http://flowtype.org/'."
     :predicate flycheck-flow--predicate
     :error-parser flycheck-flow--parse-json
     ;; js3-mode doesn't support jsx
-    :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode))
+    :modes (js-mode js-jsx-mode js2-mode js2-jsx-mode js3-mode web-mode))
 
 (flycheck-define-checker javascript-flow-coverage
   "A coverage checker for Flow.


### PR DESCRIPTION
Hi @lbolla! 

Thanks for making this. I use `web-mode` to edit JS, and wanted to use your flow plugin there as well. 

Am hereby contributing my change up. It's super small so I'd be very happy if you included it in the package, so that others who use flow and web-mode can live a more bug-free life. 

Cheers and have a good day.