### PR TITLE
Further loosen the tag regex.

### DIFF
--- a/flycheck-flow.el
+++ b/flycheck-flow.el
@@ -114,7 +114,7 @@
 (defun flycheck-flow-tag-present-p ()
   "Return true if the '// @flow' or '/* @flow */' tag is present in
    the first line of current buffer."
-  (string-match-p "^\\(//+ *@flow\\|/\\* @flow\\)" (read-first-line)))
+  (string-match-p "^\\(//+[@a-zA-Z ]*@flow\\|/\\**[@a-zA-Z ]*@flow\\)" (read-first-line)))
 
 (defun flycheck-flow--predicate ()
   "Shall we run the checker?"


### PR DESCRIPTION
Support tags for other plugins, like: /** @format @flow */
I'm also submitting a parallel PR to the flow-minor-mode, which is
required to get this working as well.